### PR TITLE
Added paging in batches of records

### DIFF
--- a/assets/package.xml
+++ b/assets/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>litmosCourseUpdatesSingleUse</members>
+        <members>litmosCourseUpdatesSingleUseTEST</members>
+        <name>ApexClass</name>
+    </types>
+    <types>
+        <members>Litmos__Program__c.Litmos_Full_Id__c</members>
+        <members>Litmos__Program__c.Full_Description__c</members>
+        <name>CustomField </name>
+    </types>
+    <types>
+        <members>litmosCourseFullData</members>
+        <name>StaticResource</name>
+    </types>
+    <version>50.0</version>
+</Package>

--- a/force-app/main/default/classes/litmosCourseUpdatesSingleUse.cls
+++ b/force-app/main/default/classes/litmosCourseUpdatesSingleUse.cls
@@ -1,0 +1,66 @@
+public class litmosCourseUpdatesSingleUse {
+    private static final Litmos__Configuration__c config = [SELECT Litmos__Api_Key__c,Litmos__Api_End_Point__c FROM Litmos__Configuration__c WHERE Litmos__Sync_Active__c = true];
+    public static void updatelitmosCourses() {
+        //uncomment this section to retrieve info from your org if it's been entered.
+        //String apikey = config.Litmos__Api_Key__c;
+        //String endpoint = config.Litmos__Api_End_Point__c + 'courses?source=sourceapp&format=json&limit=1000&sort=Name';
+        
+        //replace the apikey here with the apikey Litmos org you wish to pull learning path data from. 
+        //feel free to add &limit=XX to pull a limited number of learning paths into Salesforce OR prevent limits from being hit from Litmos. See Overview Developer API from Litmos for information.
+        String endpoint = 'https://api.litmos.com/v1.svc/courses?source=sourceapp&format=json&limit=1000&sort=Name';
+        String apikey = 'apikey';
+        
+        //to prevent callout limits, we'll need to make ONE callout and retrieve all courses. Then we'll create "new" records and upsert them using the Litmos__LitmosId__c field as the identifier
+        List<Litmos__Program__c> programsToUpsert = new List<Litmos__Program__c>();
+		HttpResponse response = new HttpResponse();
+        List<Object> results = new List<Object>();
+        Integer start = 0;
+        do{
+            response = litmosConnection.getLitmosExternalService(endpoint + '&start=' + start, apikey);
+			if(response.getStatusCode() == 200) {
+                results = (List<Object>)JSON.deserializeUntyped(response.getBody());
+                System.debug('results.size' + results.size());
+                for(Object o : results) {
+                    Map<String,Object> obj = (Map<String,Object>) o;
+                    programsToUpsert.add(new Litmos__Program__c(
+                        Name = String.valueOf(obj.get('Name')).length() > 80 ? String.valueOf(obj.get('Name')).substring(0,79) : String.valueOf(obj.get('Name')),
+                        Litmos__Active__c = Boolean.valueOf(obj.get('Active')),
+                        Full_Description__c = String.valueOf(obj.get('Description')).length() > 255 ? String.valueOf(obj.get('Description')).substring(0,254) : String.valueOf(obj.get('Description')),
+                        Litmos_Full_Id__c  = String.valueOf(obj.get('Id')),
+                        Litmos__LitmosId__c = String.valueOf(obj.get('OriginalId'))
+                    ));
+                }
+                
+        	}
+            //break the loop if test is running to avoid callout exception
+            if(Test.isRunningTest()) {
+                break;
+            }
+            start += 1000;
+        } while(results.size() > 0); 
+        
+       for(Litmos__Program__c prog : programsToUpsert) {
+           System.debug(prog.Name + ': ' + prog.Full_Description__c);
+       }
+        //this section logs info about each run into a custom object called Litmos_Sync_Logs__c. It may be uploaded at a later time. Comment out as desired.
+        Set<Id> progSuccess = new Set<Id>();
+        Set<Id> progErrors = new Set<Id>();
+        Map<Id,String> errors = new Map<Id,String>();
+        Schema.SObjectField originalIdField = Litmos__Program__c.Litmos__LitmosId__c;
+        List<Database.UpsertResult> sr = Database.upsert(programsToUpsert, originalIdField, false);
+        for(Database.UpsertResult r : sr) {
+            if(r.isSuccess()) {
+             	progSuccess.add(r.getId());   
+            } else {
+				progErrors.add(r.getId());
+                errors.put(r.getId(), String.valueOf(r.getErrors()));
+            }
+		}
+        if(progSuccess.size() > 0) {
+			litmosSyncLogs.logCourseSuccess(progSuccess);
+        }
+        if(progErrors.size() > 0) {
+            litmosSyncLogs.logCourseErrors(progErrors, errors);
+        }
+    }
+}

--- a/force-app/main/default/classes/litmosCourseUpdatesSingleUse.cls-meta.xml
+++ b/force-app/main/default/classes/litmosCourseUpdatesSingleUse.cls-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>28</minorNumber>
+        <namespace>Litmos</namespace>
+    </packageVersions>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/litmosCourseUpdatesSingleUseTEST.cls
+++ b/force-app/main/default/classes/litmosCourseUpdatesSingleUseTEST.cls
@@ -1,0 +1,34 @@
+@isTest
+public class litmosCourseUpdatesSingleUseTEST {
+	@testSetup
+    static void setup() {
+        insert new Litmos__Configuration__c(
+        	Litmos__Api_Key__c='abcde',
+            Litmos__Api_End_Point__c = 'https://api.litmos.com/v1.svc/',
+            Litmos__Sync_Active__c = true
+        );
+        
+        insert new Litmos__Program__c(
+        	Name = 'My Test Course',
+            Litmos__LitmosId__c = '123456',
+            Litmos__Active__c = true
+        );
+    }
+    @isTest
+    static void testCourseUpdates() {
+        Litmos__Configuration__c config = [SELECT Litmos__Api_End_Point__c FROM Litmos__Configuration__c];
+        
+        StaticResourceCalloutMock mock = new StaticResourceCalloutMock();
+        mock.setStaticResource('litmosCourseFullData');
+       	
+        Test.startTest();
+            Test.setMock(HttpCalloutMock.class, mock);
+        	litmosCourseUpdatesSingleUse.updatelitmosCourses();  
+        Test.stopTest();
+        System.assertEquals(1, [SELECT count() FROM Litmos__Program__c WHERE Litmos__Active__c = false AND Litmos_Full_Id__c = 'ab-cd_efg1']);
+        for(Litmos__Program__c prog : [SELECT Name,Litmos__Description__c FROM Litmos__Program__c]) {
+            System.debug('prog: ' + prog.Name + prog.Litmos__Description__c);
+        }
+        System.assertEquals('Here is a test description', [SELECT Full_Description__c FROM Litmos__Program__c].Full_Description__c);
+    }
+}

--- a/force-app/main/default/classes/litmosCourseUpdatesSingleUseTEST.cls-meta.xml
+++ b/force-app/main/default/classes/litmosCourseUpdatesSingleUseTEST.cls-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <packageVersions>
+        <majorNumber>3</majorNumber>
+        <minorNumber>28</minorNumber>
+        <namespace>Litmos</namespace>
+    </packageVersions>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/objects/Litmos__Program__c/fields/Full_Description__c.field-meta.xml
+++ b/force-app/main/default/objects/Litmos__Program__c/fields/Full_Description__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Full_Description__c</fullName>
+    <externalId>false</externalId>
+    <label>Full Description</label>
+    <length>32768</length>
+    <trackTrending>false</trackTrending>
+    <type>Html</type>
+    <visibleLines>25</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/Litmos__Program__c/fields/Litmos_Full_Id__c.field-meta.xml
+++ b/force-app/main/default/objects/Litmos__Program__c/fields/Litmos_Full_Id__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Litmos_Full_Id__c</fullName>
+    <caseSensitive>true</caseSensitive>
+    <externalId>true</externalId>
+    <label>Litmos Full Id</label>
+    <length>80</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>true</unique>
+</CustomField>

--- a/force-app/main/default/staticresources/litmosCourseFullData.resource-meta.xml
+++ b/force-app/main/default/staticresources/litmosCourseFullData.resource-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+    <cacheControl>Public</cacheControl>
+    <contentType>text/plain</contentType>
+    <description>Resource for mock test of single-upload of Litmos course info</description>
+</StaticResource>

--- a/force-app/main/default/staticresources/litmosCourseFullData.txt
+++ b/force-app/main/default/staticresources/litmosCourseFullData.txt
@@ -1,0 +1,1 @@
+[{"Id": "ab-cd_efg1","Code": "","Name": "My Test Course Name","Active": false,"ForSale": false,"OriginalId": 123456,"Description": "Here is a test description","EcommerceShortDescription": "","EcommerceLongDescription": "","CourseCodeForBulkImport": "1990036-A","Price": 0,"AccessTillDate": null,"AccessTillDays": null,"CourseTeamLibrary":false,"Languages":""}]


### PR DESCRIPTION
Added paging in batches of 1000 records to capture all courses in Litmos. Full description rich text field holds description instead of default Description field.